### PR TITLE
Mike fix typo in chinese mode variable

### DIFF
--- a/engine/table.py
+++ b/engine/table.py
@@ -259,7 +259,9 @@ class editor(object):
             return __db_chinese_mode
         # otherwise
         try:
-            if os.environ.has_key('LC_CTYPE'):
+            if os.environ.has_key('LC_ALL'):
+                __lc = os.environ['LC_ALL'].split('.')[0].lower()
+            elif os.environ.has_key('LC_CTYPE'):
                 __lc = os.environ['LC_CTYPE'].split('.')[0].lower()
             else:
                 __lc = os.environ['LANG'].split('.')[0].lower()


### PR DESCRIPTION
I found a regression I introduced when porting to GObjectIntrospection.

I made a typing mistake
in the self._chinese_mode variable. This caused a problem when
the dconf key for “chinesemode” was not yet set. Then the property
for selecting the Chinese mode in the ibus menu was empty and
and selecting the empty line with the mouse just caused an error.

This pull request fixes this.

I added a second commit to check LC_ALL first when detecting the
Chinese mode from the environment because LC_ALL has even higher
priority then LC_CTYPE and should be checked first.
