### PR TITLE
Explicit python2 for compatibility

### DIFF
--- a/engine/tabcreatedb.py
+++ b/engine/tabcreatedb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 # vim:et sts=4 sw=4
 #

--- a/tools/ibus-table-query
+++ b/tools/ibus-table-query
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # vim:fileencoding=utf-8:sw=4:et
 
 # query-ibus-table


### PR DESCRIPTION
I use Arch Linux, and since the default is Python 3, I figured that explicitly making a call to python2 would eliminate ambiguity. Also, this would ensure that editors that rely on the shebang line for syntax highlighting and such would recognize it as a python 2 script.
