### PR TITLE
filter returns a “filter object” in Python3, not a list directly as in Python2

### DIFF
--- a/engine/table.py
+++ b/engine/table.py
@@ -696,16 +696,16 @@ class editor(object):
         bm_index = self._pt.index('category')
         if self._chinese_mode == 2:
             # All Chinese characters with simplified Chinese first
-            return  filter (lambda x: x[bm_index] & 1, candidates)\
-                    +filter (lambda x: x[bm_index] & (1 << 1) and \
-                            (not x[bm_index] & 1), candidates)\
-                    + filter (lambda x: x[bm_index] & (1 << 2), candidates)
+            return  list(filter(lambda x: x[bm_index] & 1, candidates))\
+                    +list(filter(lambda x: x[bm_index] & (1 << 1) and \
+                            (not x[bm_index] & 1), candidates))\
+                    + list(filter (lambda x: x[bm_index] & (1 << 2), candidates))
         elif self._chinese_mode == 3:
             # All Chinese characters with traditional Chinese first
-            return  filter (lambda x: x[bm_index] & (1 << 1), candidates)\
-                    +filter (lambda x: x[bm_index] & 1 and\
-                    (not x[bm_index] & (1<<1)) , candidates)\
-                    + filter (lambda x: x[bm_index] & (1 << 2), candidates)
+            return  list(filter (lambda x: x[bm_index] & (1 << 1), candidates))\
+                    +list(filter(lambda x: x[bm_index] & 1 and\
+                    (not x[bm_index] & (1<<1)) , candidates))\
+                    + list(filter(lambda x: x[bm_index] & (1 << 2), candidates))
 
     def update_candidates (self):
         '''Update lookuptable'''

--- a/engine/tabsqlitedb.py
+++ b/engine/tabsqlitedb.py
@@ -208,7 +208,7 @@ class tabsqlitedb:
             # (mlen, phrase, freq, user_freq)
             # the phrases will be deparse again, and then be added
             # the characters will be discard :(
-            #chars = filter (lambda x: x[0] == 1, self.old_phrases)
+            #chars = list(filter(lambda x: x[0] == 1, self.old_phrases))
             # print chars
             phrases = [x for x in self.old_phrases if x[0] > 1]
             phrases = [[self.parse_phrase_to_tabkeys(x[1])] + list(x[1:]) for x in phrases]


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1072940#c18
