### PR TITLE
Don’t add self._single_wildcard_char and self._multi_wildcard_char to se...

### DIFF
--- a/engine/table.py
+++ b/engine/table.py
@@ -406,8 +406,10 @@ class editor(object):
         Returns “True” if candidates were found, “False” if not.
         '''
         if (self._chars_invalid
-            or (not self._py_mode and (c not in self._valid_input_chars))
-            or (self._py_mode and (c not in self._pinyin_valid_input_chars))):
+            or (not self._py_mode
+                and (c not in self._valid_input_chars + self._single_wildcard_char + self._multi_wildcard_char))
+            or (self._py_mode
+                and (c not in self._pinyin_valid_input_chars + self._single_wildcard_char + self._multi_wildcard_char))):
             self._chars_invalid += c
         else:
             self._chars_valid += c
@@ -1087,11 +1089,6 @@ class tabengine (IBus.Engine):
         if len(self._multi_wildcard_char) > 1:
             self._multi_wildcard_char = self._multi_wildcard_char[0]
 
-        self._valid_input_chars += self._single_wildcard_char
-        self._valid_input_chars += self._multi_wildcard_char
-        self._pinyin_valid_input_chars += self._single_wildcard_char
-        self._pinyin_valid_input_chars += self._multi_wildcard_char
-
         self._auto_wildcard = variant_to_value(self._config.get_value(
             self._config_section,
             "autowildcard"))
@@ -1131,7 +1128,7 @@ class tabengine (IBus.Engine):
         # Remove keys from the page up/down keys if they are needed
         # for input (for example, '=' or '-' could well be needed for
         # input. Input is more important):
-        for character in self._valid_input_chars:
+        for character in self._valid_input_chars + self._single_wildcard_char + self._multi_wildcard_char:
             keyval = IBus.unicode_to_keyval(character)
             if keyval in self._page_up_keys:
                 self._page_up_keys.remove(keyval)
@@ -1934,7 +1931,7 @@ class tabengine (IBus.Engine):
         # This is the first character typed, if it is invalid
         # input, handle it immediately here, if it is valid, continue.
         if self._editor.is_empty() and not self._editor.get_preedit_string_complete():
-            if ((keychar not in self._valid_input_chars
+            if ((keychar not in self._valid_input_chars + self._single_wildcard_char + self._multi_wildcard_char
                  or (self.db.startchars and keychar not in self.db.startchars))
                 and (not key.mask &
                      (IBus.ModifierType.MOD1_MASK |
@@ -2116,9 +2113,9 @@ class tabengine (IBus.Engine):
         # between the keys by using different SELECT_KEYS and/or
         # PAGE_UP_KEYS/PAGE_DOWN_KEYS in that table ...
         if (keychar
-            and (keychar in self._valid_input_chars
+            and (keychar in self._valid_input_chars + self._single_wildcard_char + self._multi_wildcard_char
                  or (self._editor._py_mode
-                     and keychar in self._pinyin_valid_input_chars))):
+                     and keychar in self._pinyin_valid_input_chars + self._single_wildcard_char + self._multi_wildcard_char))):
             if debug_level > 0:
                 sys.stderr.write('_table_mode_process_key_event() valid input: ')
                 sys.stderr.write('repr(keychar)=%(keychar)s\n' %{'keychar': keychar})


### PR DESCRIPTION
...lf._valid_input_chars and self._pinyin_valid_input_chars

This is because the wildcard characters can be changed with the setup
tool at runtime. If they are added to the string of valid input
characters, the old wildcards would need to be removed from that
string if the wildcards are changed. But the wildcard character may
have been in that list already before it was added as a wildcard
character. In that case, only one instance of the old wildcard
character should be removed from the string of valid input characters
if the wildcard character is changed. Replacing the wildcard
characters in the string of valid input characters when they change
seems more confusing that not adding them to that string in the first
place.

Therefore, I do not add the wildcard characters to the string of
valid input characters anymore, but that means that when checking
whether a character is a valid input character

```
if c in self._valid_input_chars:
```

is not enough anymore, now one needs

```
if c in self._valid_input_chars + self._single_wildcard_char + self._multi_wildcard_char:
```

That seems less confusing than adding the wildcard characters to
self._valid_input_chars and replacing them there when they change.
