### PR TITLE
Add a method for generating the tabkeys for sysdb.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,6 +60,7 @@ AC_CONFIG_FILES([po/Makefile.in
     engine/Makefile
     engine/ibus-engine-table
     engine/ibus-table-createdb
+    engine/ibus-table-updatedb
     engine/table.xml.in
     data/Makefile
     icons/Makefile

--- a/engine/.gitignore
+++ b/engine/.gitignore
@@ -3,4 +3,5 @@ table.xml.in
 ibus-engine-table
 ibus-table-createdb
 ibus-table-createdb.1
+ibus-table-updatedb
 *.pyc

--- a/engine/Makefile.am
+++ b/engine/Makefile.am
@@ -36,7 +36,7 @@ engine_table_DATA = \
 	$(NULL)
 engine_tabledir = $(datadir)/ibus-table/engine
 
-bin_SCRIPTS = ibus-table-createdb 
+bin_SCRIPTS = ibus-table-createdb ibus-table-updatedb
 
 libexec_SCRIPTS = ibus-engine-table
 
@@ -45,6 +45,7 @@ enginedir = $(datadir)/ibus/component
 
 EXTRA_DIST = \
 	ibus-table-createdb.in \
+	ibus-table-updatedb.in \
 	ibus-engine-table.in \
 	table.xml.in \
 	$(SGML) \
@@ -56,6 +57,7 @@ CLEANFILES = \
 	*.pyo \
 	ibus-engine-table \
 	ibus-table-createdb \
+	ibus-table-updatedb \
 	table.xml \
 	$(NULL)
 

--- a/engine/ibus-table-updatedb.in
+++ b/engine/ibus-table-updatedb.in
@@ -1,0 +1,29 @@
+#!/bin/sh
+# vim:set et sts=4 sw=4
+#
+# ibus-table - The Tables engine for IBus
+#
+# Copyright (c) 2008-2009 Yu Yuwei <acevery@gmail.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+bindir=@bindir@
+datarootdir=@datarootdir@
+datadir=@datadir@
+export IBUS_TABLE_DATA_DIR=@datarootdir@
+export IBUS_TABLE_BIN_PATH=@bindir@
+exec @PYTHON@ @datarootdir@/ibus-table/engine/tabupdatedb.py $@

--- a/engine/tabupdatedb.py
+++ b/engine/tabupdatedb.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+# vim:et sts=4 sw=4
+#
+# ibus-table - The Tables engine for IBus
+#
+# Copyright (c) 2008-2009 Yu Yuwei <acevery@gmail.com>
+# Copyright (c) 2009-2014 Caius "kaio" CHANCE <me@kaio.net>
+# Copyright (c) 2012-2014 Mike FABIAN <mfabian@redhat.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+
+import os
+import sys
+sys.path.append( os.path.dirname(os.path.abspath(__file__)) )
+import tabsqlitedb
+
+from optparse import OptionParser
+
+# we use OptionParser to parse the cmd arguments :)
+usage = "usage: %prog table.db"
+opt_parser = OptionParser(usage=usage)
+
+opt_parser.add_option( '-d', '--debug',
+        action = 'store_true', dest='debug', default = False,
+        help = 'Print extra debug messages.')
+
+opts,args = opt_parser.parse_args()
+
+
+def main():
+    def debug_print(message):
+        if opts.debug:
+            print(message)
+
+    db_path = args[0] if len(args) > 0 else None
+    if not db_path:
+        opt_parser.print_help()
+        print('\nYou need to specify the database file of the IME!')
+        sys.exit(2)
+
+    debug_print("Processing Database")
+    db = tabsqlitedb.tabsqlitedb(filename=db_path,
+                                 user_db=None,
+                                 create_database=False)
+
+    db.generate_sysdb_tabkeys()
+
+    debug_print('Done! :D')
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The design of database has been changed in commit 4fa966bc0651500bec38061ce4b33e22a15407dd.
This method helps update the database by altering the db and generating
the tabkeys from m0,m1,m2,m3,m4 in the old schema.

I don't know whether there is any existing function here. I just can't find one. I am using the Boshiamy Chinese input method. After I upgraded from Fedora 18 to Fedora 20, ibus-table keeps crashing because of this exception: 'tabsqlitedb.py:781:select_words:sqlite3.OperationalError: no such column: tabkeys'. Therefore I wrote this function. 

But I don't really know in which function should this method be called. I tried to call it in tabsqlitedb.**init**(), but you need the root permission to modify the sysdb file. Another way is to wrap it into a command line tool to allow the user upgrade the db by himself/herself, but I don't know where to put it either. So maybe please accept this pull request and help me finish it, or tell me what can I do. Thanks!
