### PR TITLE
Specify IBus version before importing in engine/main.py

### DIFF
--- a/engine/main.py
+++ b/engine/main.py
@@ -24,6 +24,9 @@
 import os
 import sys
 import optparse
+
+from gi import require_version
+require_version('IBus', '1.0')
 from gi.repository import IBus
 from gi.repository import GLib
 import re


### PR DESCRIPTION
Fix this warning when run `python3 engine/main.py`:

    engine/main.py:27: PyGIWarning: IBus was imported without specifying a version first. Use gi.require_version('IBus', '1.0') before import to ensure that the right version gets loaded.
      from gi.repository import IBus
