### PR TITLE
Avoid running initialization code of ibus_table_location.py

### DIFF
--- a/engine/tabsqlitedb.py
+++ b/engine/tabsqlitedb.py
@@ -33,7 +33,6 @@ import sqlite3
 import uuid
 import time
 import re
-import ibus_table_location
 import chinese_variants
 
 debug_level = int(0)
@@ -257,6 +256,7 @@ class tabsqlitedb:
             return
 
         if user_db != ":memory:":
+            import ibus_table_location
             tables_path = path.join(ibus_table_location.data_home(),  "tables")
             if not path.isdir(tables_path):
                 old_tables_path = os.path.join(


### PR DESCRIPTION
The code refactoring which placed "import ibus_table_location" at the start of
this script caused regression for distribution use of this ibus-table-createdb
script where there is no guarantee that the HOME directory is writable etc.

This bug is reported as release critical bug as:
https://bugs.debian.org/848756
https://bugs.debian.org/848765

I have tested this update and this resolves problem reported.

Please consider this fix to be part of the upstream code.