### PR TITLE
Make select words speed up

### DIFF
--- a/engine/table.py
+++ b/engine/table.py
@@ -2810,6 +2810,7 @@ class tabengine (IBus.Engine):
             return
         if name == u'chinesemode':
             self.set_chinese_mode(value)
+            self.db.reset_phrases_cache()
             return
         if name == u'endeffullwidthletter':
             self.set_letter_width(value, input_mode=0)
@@ -2846,6 +2847,7 @@ class tabengine (IBus.Engine):
             return
         if name == u'onechar':
             self.set_onechar_mode(value)
+            self.db.reset_phrases_cache()
             return
         if name == u'tabdeffullwidthletter':
             self.set_letter_width(value, input_mode=1)
@@ -2877,12 +2879,15 @@ class tabengine (IBus.Engine):
         if name == u'singlewildcardchar':
             self._single_wildcard_char = value
             self._editor._single_wildcard_char = value
+            self.db.reset_phrases_cache()
             return
         if name == u'multiwildcardchar':
             self._multi_wildcard_char = value
             self._editor._multi_wildcard_char = value
+            self.db.reset_phrases_cache()
             return
         if name == u'autowildcard':
             self._auto_wildcard = value
             self._editor._auto_wildcard = value
+            self.db.reset_phrases_cache()
             return

--- a/engine/tabsqlitedb.py
+++ b/engine/tabsqlitedb.py
@@ -135,6 +135,7 @@ class tabsqlitedb:
         self.old_phrases = []
         self.filename = filename
         self._user_db = user_db
+        self._phrases_cache = None
 
         if create_database or os.path.isfile(self.filename):
             self.db = sqlite3.connect(self.filename)
@@ -248,6 +249,9 @@ class tabsqlitedb:
         self.rules = self.get_rules ()
         self.possible_tabkeys_lengths = self.get_possible_tabkeys_lengths()
         self.startchars = self.get_start_chars ()
+
+        if not self.user_can_define_phrase and not self.dynamic_adjust:
+            self._phrases_cache = {}
 
         if not user_db or create_database:
             # No user database requested or we are
@@ -460,6 +464,10 @@ class tabsqlitedb:
         self.db.commit()
         self.db.execute('PRAGMA wal_checkpoint;')
 
+    def reset_phrases_cache (self):
+        if self._phrases_cache != None:
+            self._phrases_cache = {}
+
     def is_chinese (self):
         __lang = self.ime_properties.get('languages')
         if __lang:
@@ -557,6 +565,11 @@ class tabsqlitedb:
                 + 'is it a outdated database?')
             self.user_can_define_phrase = False
         self.rules = self.get_rules()
+
+        if self.user_can_define_phrase or self.dynamic_adjust:
+            self._phrases_cache = None
+        else:
+            self._phrases_cache = {}
 
     def get_rules (self):
         '''Get phrase construct rules'''
@@ -888,6 +901,11 @@ class tabsqlitedb:
         '''
         if not tabkeys:
             return []
+        # query phrases cache first
+        if self._phrases_cache != None:
+            best = self._phrases_cache.get(tabkeys)
+            if best:
+                return best
         one_char_condition = ''
         if onechar:
             # for some users really like to select only single characters
@@ -962,6 +980,8 @@ class tabsqlitedb:
             chinese_mode=chinese_mode)
         if debug_level > 1:
             sys.stderr.write("select_words() best=%s\n" %repr(best))
+        if self._phrases_cache != None:
+            self._phrases_cache[tabkeys] = best
         return best
 
     def select_chinese_characters_by_pinyin(


### PR DESCRIPTION
I found that table sqlite database based cache is very slow.

The ibus-table process's cpu usage is 100% when i hod a key down on a Intel i3 2.53Ghz, and that table contains about 2 hundred thousand records.

This patch can make cpu usage down to 10% in same test and input can immedidate stop when i released the key.