### PR TITLE
Make output of ibus-table-createdb deterministic

### DIFF
--- a/engine/tabsqlitedb.py
+++ b/engine/tabsqlitedb.py
@@ -220,7 +220,7 @@ class TabSqliteDb:
             SELECT val FROM main.ime WHERE attr = :attr;'''
             insert_sqlstr = '''
             INSERT INTO main.ime (attr, val) VALUES (:attr, :val);'''
-            for attr in self._default_ime_attributes:
+            for attr in sorted(self._default_ime_attributes):
                 sqlargs = {
                     'attr': attr,
                     'val': self._default_ime_attributes[attr]


### PR DESCRIPTION
With this patch, the output of ibus-table-createdb would be of determined order as proposed by the Reproducible Builds project (https://reproducible-builds.org/).

Downstream Debian bug report can be found at https://bugs.debian.org/797521 .

Even though python's dict has become ordered since Python 3.6+, a `sorted()` function would be harmless and benefit users of Python 3.5, like users of Debian 9.