### PR TITLE
allow = character in attribute values

### DIFF
--- a/engine/tabcreatedb.py
+++ b/engine/tabcreatedb.py
@@ -349,7 +349,10 @@ def main() -> None:
 
     def attribute_parser(f: Iterable[str]) -> Iterable[Tuple[str, str]]:
         for line in f:
-            attr, val = re.fullmatch(r'(.*?)==?(.*)', line).groups()
+            match = re.fullmatch(r'(.*?)==?(.*)', line)
+            if match is None:
+                raise ValueError(f'Invalid attribute format: {line!r}')
+            attr, val = match.groups()
             attr = attr.strip().lower()
             val = val.strip()
             yield (attr, val)

--- a/engine/tabcreatedb.py
+++ b/engine/tabcreatedb.py
@@ -349,10 +349,7 @@ def main() -> None:
 
     def attribute_parser(f: Iterable[str]) -> Iterable[Tuple[str, str]]:
         for line in f:
-            try:
-                attr, val = line.strip().split('=')
-            except Exception:
-                attr, val = line.strip().split('==')
+            attr, val = re.fullmatch(r'(.*?)==?(.*)', line).groups()
             attr = attr.strip().lower()
             val = val.strip()
             yield (attr, val)


### PR DESCRIPTION
simple patch to allow the `=` character in attribute lines of table source files, e.g.

```
DESCRIPTION = Arrows can be inserted by preceding them with backslash, e.g. \=>
```

(previously this would cause the parser to crash)